### PR TITLE
ci: Replace BuildJet with GitHub-hosted ARM runners

### DIFF
--- a/.github/actions/build-docker-images/action.yml
+++ b/.github/actions/build-docker-images/action.yml
@@ -18,13 +18,27 @@ runs:
   using: composite
   steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v5
+
+    - name: Install Docker (ARM runners)
+      if: runner.arch == 'ARM64'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ca-certificates curl gnupg make
+        sudo install -m 0755 -d /etc/apt/keyrings
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+        sudo chmod a+r /etc/apt/keyrings/docker.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+        sudo apt-get update
+        sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin
+        sudo chmod 666 /var/run/docker.sock
 
     - name: Configure DockerHub
       uses: ./.github/actions/configure-dockerhub
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v4
       with:
         platforms: linux/${{ inputs.arch }}
 

--- a/.github/actions/build-docker-images/action.yml
+++ b/.github/actions/build-docker-images/action.yml
@@ -24,15 +24,20 @@ runs:
       if: runner.arch == 'ARM64'
       shell: bash
       run: |
-        sudo apt-get update
-        sudo apt-get install -y ca-certificates curl gnupg make
-        sudo install -m 0755 -d /etc/apt/keyrings
-        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-        sudo chmod a+r /etc/apt/keyrings/docker.gpg
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-        sudo apt-get update
-        sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin
-        sudo chmod 666 /var/run/docker.sock
+        # Use sudo if available (bare-metal runner), otherwise run as root (container)
+        SUDO=""
+        if command -v sudo &>/dev/null; then
+          SUDO="sudo"
+        fi
+        $SUDO apt-get update
+        $SUDO apt-get install -y ca-certificates curl gnupg make
+        $SUDO install -m 0755 -d /etc/apt/keyrings
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | $SUDO gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+        $SUDO chmod a+r /etc/apt/keyrings/docker.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | $SUDO tee /etc/apt/sources.list.d/docker.list > /dev/null
+        $SUDO apt-get update
+        $SUDO apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin
+        $SUDO chmod 666 /var/run/docker.sock
 
     - name: Configure DockerHub
       uses: ./.github/actions/configure-dockerhub

--- a/.github/actions/build-docker-images/action.yml
+++ b/.github/actions/build-docker-images/action.yml
@@ -24,17 +24,23 @@ runs:
       if: runner.arch == 'ARM64'
       shell: bash
       run: |
+        if command -v docker &>/dev/null; then
+          echo "Docker CLI already available, skipping install"
+          exit 0
+        fi
         # Use sudo if available (bare-metal runner), otherwise run as root (container)
         SUDO=""
         if command -v sudo &>/dev/null; then
           SUDO="sudo"
         fi
+        # Detect OS for correct Docker repo (ubuntu vs debian)
+        . /etc/os-release
         $SUDO apt-get update
         $SUDO apt-get install -y ca-certificates curl gnupg make
         $SUDO install -m 0755 -d /etc/apt/keyrings
-        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | $SUDO gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+        curl -fsSL "https://download.docker.com/linux/${ID}/gpg" | $SUDO gpg --dearmor -o /etc/apt/keyrings/docker.gpg
         $SUDO chmod a+r /etc/apt/keyrings/docker.gpg
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | $SUDO tee /etc/apt/sources.list.d/docker.list > /dev/null
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/${ID} ${VERSION_CODENAME} stable" | $SUDO tee /etc/apt/sources.list.d/docker.list > /dev/null
         $SUDO apt-get update
         $SUDO apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin
         $SUDO chmod 666 /var/run/docker.sock

--- a/.github/workflows/pushproxng-ci.yml
+++ b/.github/workflows/pushproxng-ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: ${{ matrix.image }} - ${{ matrix.arch }} docker build
-    runs-on: ${{ fromJSON('{"arm64":"2vcpu-ubuntu-2204-arm","amd64":"ubuntu-20.04"}')[matrix.arch] }}
+    runs-on: ${{ fromJSON('{"arm64":"2vcpu-ubuntu-2204-arm","amd64":"ubuntu-22.04"}')[matrix.arch] }}
     container:
       image: luthersystems/build-go:v0.0.68
     strategy:

--- a/.github/workflows/pushproxng-ci.yml
+++ b/.github/workflows/pushproxng-ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: ${{ matrix.image }} - ${{ matrix.arch }} docker build
-    runs-on: ${{ fromJSON('{"arm64":"buildjet-2vcpu-ubuntu-2204-arm","amd64":"ubuntu-20.04"}')[matrix.arch] }}
+    runs-on: ${{ fromJSON('{"arm64":"2vcpu-ubuntu-2204-arm","amd64":"ubuntu-20.04"}')[matrix.arch] }}
     container:
       image: luthersystems/build-go:v0.0.68
     strategy:
@@ -18,7 +18,7 @@ jobs:
         image:
           - pushprox
     steps:
-      - uses: actions/checkout@v3.5.0
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # include tags for VERSION detection
       - name: Run CI

--- a/.github/workflows/pushproxng-release.yml
+++ b/.github/workflows/pushproxng-release.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   build-push:
     name: ${{ matrix.image }} - ${{ matrix.arch }} docker build
-    runs-on: ${{ fromJSON('{"arm64":"buildjet-2vcpu-ubuntu-2204-arm","amd64":"ubuntu-20.04"}')[matrix.arch] }}
+    runs-on: ${{ fromJSON('{"arm64":"2vcpu-ubuntu-2204-arm","amd64":"ubuntu-20.04"}')[matrix.arch] }}
     container:
       image: luthersystems/build-go:v0.0.68
     strategy:
@@ -20,7 +20,7 @@ jobs:
         image:
           - pushprox
     steps:
-      - uses: actions/checkout@v3.5.0
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # include tags for VERSION detection
       - name: Build container
@@ -35,10 +35,10 @@ jobs:
     - build-push
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v5
     - name:  Configure DockerHub
       uses: ./.github/actions/configure-dockerhub
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v4
     - name: Create and push manifest for multiarch
       run:  make push-manifests GIT_TAG=$GITHUB_REF_NAME

--- a/.github/workflows/pushproxng-release.yml
+++ b/.github/workflows/pushproxng-release.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   build-push:
     name: ${{ matrix.image }} - ${{ matrix.arch }} docker build
-    runs-on: ${{ fromJSON('{"arm64":"2vcpu-ubuntu-2204-arm","amd64":"ubuntu-20.04"}')[matrix.arch] }}
+    runs-on: ${{ fromJSON('{"arm64":"2vcpu-ubuntu-2204-arm","amd64":"ubuntu-22.04"}')[matrix.arch] }}
     container:
       image: luthersystems/build-go:v0.0.68
     strategy:
@@ -30,7 +30,7 @@ jobs:
           image: .
           git_tag: $GITHUB_REF_NAME
   push-manifests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
     - build-push
     steps:


### PR DESCRIPTION
## Summary

- Replace BuildJet ARM runner with GitHub-hosted `2vcpu-ubuntu-2204-arm`
- Bump `actions/checkout` v3 -> v5, `docker/setup-buildx-action` v2 -> v4 (Node.js 24)
- Add Docker install step for ARM runners (not pre-installed on GitHub ARM)

Closes luthersystems/pushproxng#10

## Reference

Already fixed in luthersystems/mars#115 and luthersystems/buildenv#56.